### PR TITLE
update bem-environ to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "bem" : "0.7.9",
-    "bem-environ" : "1.3.1"
+    "bem-environ" : "~1.4.0"
   },
   "devDependencies": {},
   "private": true


### PR DESCRIPTION
для решения https://github.com/bem/project-stub/pull/38 и https://github.com/bem/project-stub/pull/39 надо обновить bem-environ до 1.4.0 что бы была возможность использовать **getTechResolver**

// cc @tadatuta 
