### PR TITLE
gulp: Run optimization only in production mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "gulp-concat": "^2.6.0",
     "gulp-csso": "^2.0.0",
     "gulp-debug": "^3.0.0",
+    "gulp-if": "^2.0.2",
     "gulp-one-of": "^1.0.0",
     "gulp-postcss": "^6.2.0",
     "gulp-uglify": "^2.0.0",


### PR DESCRIPTION
Saves about a second of build time in dev mode.
To build in production mode `YENV=production` should be used as in ENB build.